### PR TITLE
Use pip_index_url on install if set by writing into ~/.pip/pip.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It is installs it into a virtualenv on the box.
 - monasca_agent_dimensions: 'role:monitoring,region:a'
 - monasca_api_url: if undefined it will be pulled from the keystone service catalog.
 - monasca_agent_version: Defines a specific version to install, defaults to latest
+- pip_index_url: Index URL to use instead of the default for installing pip packages
 
 Optionally supply monasca_checks varible which is a dictionary with each entry consisting of a plugin name followed by the
 plugin config, typically with two sections init_config and instances. Refer to the specific monasca-agent plugin documentation

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ monasca_agent_check_frequency: 60
 
 skip_install: False
 monasca_virtualenv_dir: /opt/monasca
+pip_conf_dir: ~/.pip

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- include: pip_index.yml
+  when: not skip_install
+
 - name: Install deps to avoid pip doing compilation or enable it
   apt: name={{item}} state=present
   with_items: dependencies

--- a/tasks/pip_index.yml
+++ b/tasks/pip_index.yml
@@ -1,0 +1,8 @@
+---
+- name: Create pip conf dir if pip index URL specified
+  file: path={{ pip_conf_dir }} state=directory owner=root group={{monasca_group}} mode=770
+  when: pip_index_url is defined
+
+- name: Use pip index URL if specified
+  template: dest="{{ pip_conf_dir }}/pip.conf" src=pip.conf.j2 backup=yes owner=root group=root mode=660
+  when: pip_index_url is defined

--- a/templates/pip.conf.j2
+++ b/templates/pip.conf.j2
@@ -1,0 +1,2 @@
+[global]
+index-url = {{ pip_index_url }}


### PR DESCRIPTION
We can merge this after the tag if needed
