### PR TITLE
Add python-pip and python-dev as dependencies

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- include_vars: "{{ ansible_distribution }}.yml"
+  when: not skip_install
+
 - include: pip_index.yml
   when: not skip_install
 
@@ -7,8 +10,9 @@
   with_items: dependencies
   when: not skip_install
 
-- name: pip install virtualenv
-  pip: name=virtualenv state=present
+- name: pip install monasca-agent in a virtualenv
+  pip: name=monasca-agent state=latest virtualenv="{{monasca_virtualenv_dir}}"
+  notify: run monasca-setup
   when: not skip_install
 
 - name: pip install latest monasca-agent in a virtualenv

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,17 +2,16 @@
 - include_vars: "{{ ansible_distribution }}.yml"
   when: not skip_install
 
+- name: Install virtualenv
+  apt: name="{{ virtualenv_pkg }}" state=present
+  when: not skip_install
+
 - include: pip_index.yml
   when: not skip_install
 
 - name: Install deps to avoid pip doing compilation or enable it
   apt: name={{item}} state=present
   with_items: dependencies
-  when: not skip_install
-
-- name: pip install monasca-agent in a virtualenv
-  pip: name=monasca-agent state=latest virtualenv="{{monasca_virtualenv_dir}}"
-  notify: run monasca-setup
   when: not skip_install
 
 - name: pip install latest monasca-agent in a virtualenv

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,1 @@
+virtualenv_pkg: virtualenv

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,1 @@
+virtualenv_pkg: python-virtualenv

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,5 +1,7 @@
 ---
 dependencies:
+  - python-pip
+  - python-dev
   - python-yaml
   - build-essential
   - libxml2-dev

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,5 @@
 ---
 dependencies:
-  - python-pip
   - python-dev
   - python-yaml
   - build-essential


### PR DESCRIPTION
pip is needed to install the agent. python-dev is needed if
compilation is needed
