### PR TITLE
Remove the virtualenv install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Installs the [monasca-agent](https://github.com/stackforge/monasca-agent) part o
 It is installs it into a virtualenv on the box.
 
 ## Requirements
+virtualenv must be installed on the system.
+
 - keystone_url:
 - monasca_agent_user:
 - monasca_agent_password:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,4 @@
 ---
-- include_vars: "{{ ansible_distribution }}.yml"
-  when: not skip_install
-
-- name: Install virtualenv
-  apt: name="{{ virtualenv_pkg }}" state=present
-  when: not skip_install
-
 - include: pip_index.yml
   when: not skip_install
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,1 +1,0 @@
-virtualenv_pkg: virtualenv

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,1 +1,0 @@
-virtualenv_pkg: python-virtualenv


### PR DESCRIPTION
The proper package for Debian depends on the version of debian, rather
than put all the detailed logic for that here just assume it needs to be
installed and put the installation of virtualenv into the appropriate
playbooks.
