### PR TITLE
Restructure the playbook so just parts of it can be invoked

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ virtualenv must be installed on the system.
 - monasca_api_url: if undefined it will be pulled from the keystone service catalog.
 - monasca_agent_version: Defines a specific version to install, defaults to latest
 - pip_index_url: Index URL to use instead of the default for installing pip packages
+- run_mode: One of Deploy, Stop, Install, Start, or Use. The default is Deploy which will do Install, Configure, then Start. 'Use' can be set if the only desire is to use the monasca_agent_plugin module
 
 Optionally supply monasca_checks varible which is a dictionary with each entry consisting of a plugin name followed by the
 plugin config, typically with two sections init_config and instances. Refer to the specific monasca-agent plugin documentation
@@ -48,6 +49,11 @@ in system only mode then as different services are installed they can selectivel
         names:
             - ntp
             - mysql
+
+You must have the monasca-agent role in your playbook. If the agent is already deployed and you just need to use monasca_agent_plugin, then you can add the role in and have it skip all install, configure and start steps by using these lines in your playbook:
+
+  roles:
+    - {role: monasca-agent, run_mode: Use}
 
 To copy custom detection and/or check plugins to the machine before running the monasca_agent_plugin module, use the
 [copy module](http://docs.ansible.com/copy_module.html) with the published variables `monasca_agent_check_plugin_dir` or `monasca_agent_detection_plugin_dir`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,4 @@ monasca_agent_check_frequency: 60
 skip_install: False
 monasca_virtualenv_dir: /opt/monasca
 pip_conf_dir: ~/.pip
+run_mode: Deploy

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,0 +1,22 @@
+---
+- name: create conf.d dir and custom plugin dirs
+  file: path="{{item}}" state=directory owner=root group=root mode=755
+  with_items:
+    - "{{monasca_conf_dir}}/agent/conf.d"
+    - "{{monasca_agent_check_plugin_dir}}"
+    - "{{monasca_agent_detection_plugin_dir}}"
+
+- name: Create additional plugins config
+  template: dest="{{monasca_conf_dir}}/agent/conf.d/{{item.key}}.yaml" src=plugin.yaml.j2 owner=root group=root mode=644
+  with_dict: monasca_checks
+  notify: run monasca-setup
+
+# Instead of running this directly by creating a file to run it changes such as user/pass will trigger a rerun. Also a user can run it manually
+- name: Create reconfigure script
+  template: dest="{{agent_reconfigure_script}}" src=monasca-reconfigure.j2 owner=root group=root mode=750
+  notify: run monasca-setup
+
+- meta: flush_handlers
+
+- name: Enable Monasca-Agent
+  service: name=monasca-agent state=started enabled=yes

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,16 @@
+---
+- include: pip_index.yml
+
+- name: Install deps to avoid pip doing compilation or enable it
+  apt: name={{item}} state=present
+  with_items: dependencies
+
+- name: pip install latest monasca-agent in a virtualenv
+  pip: name=monasca-agent state=latest virtualenv="{{monasca_virtualenv_dir}}"
+  notify: run monasca-setup
+  when: monasca_agent_version is not defined
+
+- name: pip install a specific version of monasca-agent in a virtualenv
+  pip: name=monasca-agent state=present version="{{monasca_agent_version}}" virtualenv="{{monasca_virtualenv_dir}}"
+  notify: run monasca-setup
+  when: monasca_agent_version is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,40 +1,12 @@
 ---
-- include: pip_index.yml
-  when: not skip_install
+- include: stop.yml
+  when:  run_mode == 'Stop'
 
-- name: Install deps to avoid pip doing compilation or enable it
-  apt: name={{item}} state=present
-  with_items: dependencies
-  when: not skip_install
+- include: install.yml
+  when: not skip_install and ( run_mode == 'Install' or run_mode == 'Deploy' )
 
-- name: pip install latest monasca-agent in a virtualenv
-  pip: name=monasca-agent state=latest virtualenv="{{monasca_virtualenv_dir}}"
-  notify: run monasca-setup
-  when: not skip_install and monasca_agent_version is not defined
+- include: configure.yml
+  when:  run_mode == 'Configure' or run_mode == 'Deploy' 
 
-- name: pip install a specific version of monasca-agent in a virtualenv
-  pip: name=monasca-agent state=present version="{{monasca_agent_version}}" virtualenv="{{monasca_virtualenv_dir}}"
-  notify: run monasca-setup
-  when: not skip_install and monasca_agent_version is defined
-
-- name: create conf.d dir and custom plugin dirs
-  file: path="{{item}}" state=directory owner=root group=root mode=755
-  with_items:
-    - "{{monasca_conf_dir}}/agent/conf.d"
-    - "{{monasca_agent_check_plugin_dir}}"
-    - "{{monasca_agent_detection_plugin_dir}}"
-
-- name: Create additional plugins config
-  template: dest="{{monasca_conf_dir}}/agent/conf.d/{{item.key}}.yaml" src=plugin.yaml.j2 owner=root group=root mode=644
-  with_dict: monasca_checks
-  notify: run monasca-setup
-
-# Instead of running this directly by creating a file to run it changes such as user/pass will trigger a rerun. Also a user can run it manually
-- name: Create reconfigure script
-  template: dest="{{agent_reconfigure_script}}" src=monasca-reconfigure.j2 owner=root group=root mode=750
-  notify: run monasca-setup
-
-- meta: flush_handlers
-
-- name: Enable Monasca-Agent
-  service: name=monasca-agent state=started enabled=yes
+- include: start.yml
+  when:  run_mode == 'Start' or run_mode == 'Deploy' 

--- a/tasks/start.yml
+++ b/tasks/start.yml
@@ -1,0 +1,3 @@
+---
+- name: Start and Enable Monasca-Agent
+  service: name=monasca-agent state=started enabled=yes

--- a/tasks/stop.yml
+++ b/tasks/stop.yml
@@ -1,0 +1,3 @@
+---
+- name: Stop Monasca-Agent
+  service: name=monasca-agent state=stopped


### PR DESCRIPTION
The default is to do install, configure and then start

Add documentation on how to use the role to just load monasca_agent_plugin
