### PR TITLE
Quote monasca-reconfigure.j2

### DIFF
--- a/templates/monasca-reconfigure.j2
+++ b/templates/monasca-reconfigure.j2
@@ -1,13 +1,13 @@
 #!/bin/sh
-"{{monasca_virtualenv_dir}}/bin/monasca-setup" \
-    -u "{{monasca_agent_user}}" \
-    -p "{{monasca_agent_password}}" \
-    {% if monasca_agent_service is defined %} -s "{{monasca_agent_service}}" {% endif %} \
-    --keystone_url "{{keystone_url}}" \
-    --project_name "{{monasca_agent_project}}" \
-    {% if monasca_api_url is defined %} --monasca_url "{{monasca_api_url}}" {% endif %} \
-    {% if monasca_agent_dimensions is defined %} --dimensions "{{monasca_agent_dimensions}}" {% endif %} \
-    --check_frequency "{{monasca_agent_check_frequency}}" \
+'{{monasca_virtualenv_dir}}/bin/monasca-setup' \
+    -u '{{monasca_agent_user}}' \
+    -p '{{monasca_agent_password}}' \
+    {% if monasca_agent_service is defined %} -s '{{monasca_agent_service}}' {% endif %} \
+    --keystone_url '{{keystone_url}}' \
+    --project_name '{{monasca_agent_project}}' \
+    {% if monasca_api_url is defined %} --monasca_url '{{monasca_api_url}}' {% endif %} \
+    {% if monasca_agent_dimensions is defined %} --dimensions '{{monasca_agent_dimensions}}' {% endif %} \
+    --check_frequency '{{monasca_agent_check_frequency}}' \
     {% if monasca_agent_system_only %} --system_only {% endif %} \
-    {% if monasca_log_level is defined %} --log_level "{{monasca_log_level}}" {% endif %} \
+    {% if monasca_log_level is defined %} --log_level '{{monasca_log_level}}' {% endif %} \
     --overwrite

--- a/templates/monasca-reconfigure.j2
+++ b/templates/monasca-reconfigure.j2
@@ -1,2 +1,13 @@
 #!/bin/sh
-{{monasca_virtualenv_dir}}/bin/monasca-setup -u {{monasca_agent_user}} -p {{monasca_agent_password}} {% if monasca_agent_service is defined %} -s {{monasca_agent_service}} {% endif %} --keystone_url {{keystone_url}} --project_name {{monasca_agent_project}} {% if monasca_api_url is defined %} --monasca_url {{monasca_api_url}} {% endif %} {% if monasca_agent_dimensions is defined %} --dimensions {{monasca_agent_dimensions}} {% endif %} --check_frequency {{monasca_agent_check_frequency}} {% if monasca_agent_system_only %} --system_only {% endif %} {% if monasca_log_level is defined %} --log_level {{monasca_log_level}} {% endif %} --overwrite
+"{{monasca_virtualenv_dir}}/bin/monasca-setup" \
+    -u "{{monasca_agent_user}}" \
+    -p "{{monasca_agent_password}}" \
+    {% if monasca_agent_service is defined %} -s "{{monasca_agent_service}}" {% endif %} \
+    --keystone_url "{{keystone_url}}" \
+    --project_name "{{monasca_agent_project}}" \
+    {% if monasca_api_url is defined %} --monasca_url "{{monasca_api_url}}" {% endif %} \
+    {% if monasca_agent_dimensions is defined %} --dimensions "{{monasca_agent_dimensions}}" {% endif %} \
+    --check_frequency "{{monasca_agent_check_frequency}}" \
+    {% if monasca_agent_system_only %} --system_only {% endif %} \
+    {% if monasca_log_level is defined %} --log_level "{{monasca_log_level}}" {% endif %} \
+    --overwrite


### PR DESCRIPTION
Autogenerated passwords are causing issues when monasca-agent are
starting up. Quoting values in shell scripts is good hygiene anyway.

Also split over multiple lines for readability.
