### PR TITLE
Installing psutil after agent

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,3 +19,7 @@
   pip: name=monasca-agent state=present version="{{monasca_agent_version}}" virtualenv="{{monasca_virtualenv_dir}}"
   notify: run monasca-setup
   when: monasca_agent_version is defined
+
+- name: pip install psutil==3.0.1
+  pip: name=psutil version=3.0.1 virtualenv="{{monasca_virtualenv_dir}}"
+  notify: run monasca-setup


### PR DESCRIPTION
We removed psutil from the agent requirements so that we could integrate into
the OpenStack release constraints.  We're installing the version we want after
installation of the agent now.
