### PR TITLE
Fix mode arguments to be octal not decimal numbers

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,20 +2,20 @@
 # ©Copyright 2015 Hewlett-Packard Development Company, L.P.
 
 - name: create conf.d dir and custom plugin dirs
-  file: path="{{item}}" state=directory owner=root group=root mode=755
+  file: path="{{item}}" state=directory owner=root group=root mode=0755
   with_items:
     - "{{monasca_conf_dir}}/agent/conf.d"
     - "{{monasca_agent_check_plugin_dir}}"
     - "{{monasca_agent_detection_plugin_dir}}"
 
 - name: Create additional plugins config
-  template: dest="{{monasca_conf_dir}}/agent/conf.d/{{item.key}}.yaml" src=plugin.yaml.j2 owner=root group=root mode=644
+  template: dest="{{monasca_conf_dir}}/agent/conf.d/{{item.key}}.yaml" src=plugin.yaml.j2 owner=root group=root mode=0644
   with_dict: monasca_checks
   notify: run monasca-setup
 
 # Instead of running this directly by creating a file to run it changes such as user/pass will trigger a rerun. Also a user can run it manually
 - name: Create reconfigure script
-  template: dest="{{agent_reconfigure_script}}" src=monasca-reconfigure.j2 owner=root group=root mode=750
+  template: dest="{{agent_reconfigure_script}}" src=monasca-reconfigure.j2 owner=root group=root mode=0750
   notify: run monasca-setup
 
 - meta: flush_handlers

--- a/tasks/pip_index.yml
+++ b/tasks/pip_index.yml
@@ -2,9 +2,9 @@
 # ©Copyright 2015 Hewlett-Packard Development Company, L.P.
 
 - name: Create pip conf dir if pip index URL specified
-  file: path={{ pip_conf_dir }} state=directory owner=root group=root mode=770
+  file: path={{ pip_conf_dir }} state=directory owner=root group=root mode=0770
   when: pip_index_url is defined
 
 - name: Use pip index URL if specified
-  template: dest="{{ pip_conf_dir }}/pip.conf" src=pip.conf.j2 backup=yes owner=root group=root mode=660
+  template: dest="{{ pip_conf_dir }}/pip.conf" src=pip.conf.j2 backup=yes owner=root group=root mode=0660
   when: pip_index_url is defined


### PR DESCRIPTION
From the ansible documentation:
"For those used to /usr/bin/chmod remember that modes are
actually octal numbers (like 0644). Leaving off the leading
zero will likely have unexpected results."
