### PR TITLE
Add RedHat/CentOS support to Agent deployment

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,11 +1,17 @@
 ---
-# ©Copyright 2015 Hewlett-Packard Development Company, L.P.
+# ©Copyright 2015-2016 Hewlett Packard Enterprise Development Company, LP
 
 - include: pip_index.yml
 
 - name: Install deps to avoid pip doing compilation or enable it
   apt: name={{item}} state=present
-  with_items: dependencies
+  with_items: dependencies_deb
+  when: ansible_os_family == 'Debian'
+  
+- name: Install rpms to avoid pip doing compilation or enable it
+  yum: name={{item}} state=present
+  with_items: dependencies_rpm
+  when: ansible_os_family == 'RedHat'
 
 - name: Upgrade pip in virtualenv
   pip: name=pip version=7.1.2 virtualenv="{{monasca_virtualenv_dir}}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,12 +1,18 @@
 ---
-# ©Copyright 2015 Hewlett-Packard Development Company, L.P.
+# ©Copyright 2015-2016 Hewlett Packard Enterprise Development Company, LP
 
-dependencies:
+dependencies_deb:
   - python-dev
   - python-yaml
   - build-essential
   - libxml2-dev
   - libxslt1-dev
+dependencies_rpm:
+  - python-devel
+  - PyYAML
+  - libxml2-devel
+  - libxslt-devel
+  - gcc
 monasca_conf_dir: /etc/monasca
 monasca_agent_check_plugin_dir: /usr/lib/monasca/agent/custom_checks.d/
 monasca_agent_detection_plugin_dir: /usr/lib/monasca/agent/custom_detect.d/


### PR DESCRIPTION
This patch adds the ability to deploy the Agent using Ansible on a
RedHat or CentOS host.  Tested using CentOS 7.
