### PR TITLE
Upgrade setuptools in venv

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,6 +16,9 @@
 - name: Upgrade pip in virtualenv
   pip: name=pip version=7.1.2 virtualenv="{{monasca_virtualenv_dir}}"
 
+- name: Upgrade setuptools in virtualenv
+  pip: name=setuptools version=1.4 virtualenv="{{monasca_virtualenv_dir}}"
+
 - name: pip install latest monasca-agent in a virtualenv
   pip: name=monasca-agent state=latest virtualenv="{{monasca_virtualenv_dir}}"
   notify: run monasca-setup


### PR DESCRIPTION
Recent versions of the Monasca agent require a minimum of
setuptools 1.4. If an earlier version is installed the installation
of the Monasca agent fails, complaining that it can't upgrade
setuptools, and that version >=1.4 is required.

An alternative would be to support installing arbitrary pip
packages into the venv via a user configurable variable.